### PR TITLE
Fix for GNU bash, version 5.1.4

### DIFF
--- a/ipforwarding.sh
+++ b/ipforwarding.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-if [ "$1" -eq "enable" ]
+if [ "$1" = "enable" ]
     then
         sudo sysctl -w net.ipv4.ip_forward=1
         sudo iptables -t nat -A PREROUTING -i wlan1 -p tcp --dport 443 -j REDIRECT --to-port 8080
         sudo iptables -t nat -A PREROUTING -i wlan1 -p tcp --dport 80 -j REDIRECT --to-port 8080
-elif [ "$1" -eq "disable" ]
+elif [ "$1" = "disable" ]
     then
         sudo sysctl -w net.ipv4.ip_forward=0
         sudo iptables -t nat -A PREROUTING -i wlan1 -p tcp --dport 443 -j REDIRECT --to-port 8080 -D


### PR DESCRIPTION
according to [1], `-eq` is for numerical comparisons. String comparisons should be done with `=`.

Before fix: `./ipforwarding.sh: line 2: [: enable: integer expression expected`
After fix: Everything works

```bash
$ bash --version
GNU bash, version 5.1.4(1)-release (x86_64-pc-linux-gnu)
$ /bin/[ --version
[ (GNU coreutils) 8.32
```

[1]: https://linuxcommand.org/lc3_man_pages/testh.html